### PR TITLE
Add missing metainfo entries

### DIFF
--- a/com.jetbrains.Rider.metainfo.xml
+++ b/com.jetbrains.Rider.metainfo.xml
@@ -29,7 +29,17 @@
   </screenshots>
   <update_contact>sakcheen+flathub_AT_gmail.com</update_contact>
   <content_rating type="oars-1.1"/>
-  <releases>
+  <releases>  
+    <release version="2021.1.5" date="2021-06-22"/>
+    <release version="2021.1.4" date="2021-06-14"/>
+    <release version="2021.1.3" date="2021-05-26"/>
+    <release version="2021.1.2" date="2021-04-23"/>
+    <release version="2021.1.1" date="2021-04-10"/>
+    <release version="2021.1" date="2021-04-08"/>
+    <release version="2020.3.4" date="2021-03-17"/>
+    <release version="2020.3.3" date="2021-02-22"/>
+    <release version="2020.3.2" date="2020-12-30"/>
+    <release version="2020.3.1" date="2020-12-24"/>
     <release version="2020.3" date="2020-12-14"/>
     <release version="2020.2.4" date="2020-10-01"/>
     <release version="2020.2.3" date="2020-09-18"/>


### PR DESCRIPTION
Flathub shows 2020.3 as latest version currently. These missing entries should fix that.