### PR TITLE
Add libsecret

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "jetbrains-flatpak-wrapper"]
 	path = jetbrains-flatpak-wrapper
 	url = https://github.com/Lctrs/jetbrains-flatpak-wrapper.git
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/com.jetbrains.Rider.yaml
+++ b/com.jetbrains.Rider.yaml
@@ -12,6 +12,7 @@ finish-args:
   - --share=network
   - --socket=pulseaudio
   - --filesystem=host
+  - --filesystem=xdg-run/keyring
   - --socket=session-bus
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.secrets
@@ -19,6 +20,8 @@ finish-args:
   - --device=all
   - --env=RIDER_JDK=${FLATPAK_DEST}/extra/rider/jre64
 modules:
+  - shared-modules/libsecret/libsecret.json
+
   - name: rider
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
While `--talk-name=org.freedesktop.secrets` is currently in this flatpak's finish-args, it's not actually able to utilize libsecret, since libsecret is missing from the flatpak. As such, when Rider tries to store passwords in the system keychain, it fails.

This PR adds libsecret from the shared modules, and allows access to `xdg-run/keyring`, which seems to be required for it to function.