### PR TITLE
Add Wayland support

### DIFF
--- a/com.jetbrains.Rider.yaml
+++ b/com.jetbrains.Rider.yaml
@@ -9,6 +9,7 @@ tags:
 finish-args:
   - --share=ipc
   - --socket=x11
+  - --socket=wayland
   - --share=network
   - --socket=pulseaudio
   - --filesystem=host


### PR DESCRIPTION
Enables the Wayland socket so Rider will launch on Wayland-based systems such as Fedora