### PR TITLE
Use JetBrains flatpak wrapper not using submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "jetbrains-flatpak-wrapper"]
-	path = jetbrains-flatpak-wrapper
-	url = https://github.com/Lctrs/jetbrains-flatpak-wrapper.git
 [submodule "shared-modules"]
 	path = shared-modules
 	url = https://github.com/flathub/shared-modules.git

--- a/com.jetbrains.Rider.yaml
+++ b/com.jetbrains.Rider.yaml
@@ -78,5 +78,6 @@ modules:
       - -Dprogram_name=rider
       - -Deditor_title=Rider
     sources:
-      - type: dir
-        path: jetbrains-flatpak-wrapper
+      - type: git
+        url: https://github.com/Lctrs/jetbrains-flatpak-wrapper.git
+        commit: 5a054811ab2144ceaf343169b240a70eeb4dfb47


### PR DESCRIPTION
Lint complains now and builds have been failing.