### PR TITLE
chore: Use Wayland by default

### DIFF
--- a/com.jetbrains.Rider.yaml
+++ b/com.jetbrains.Rider.yaml
@@ -8,7 +8,8 @@ tags:
   - proprietary
 finish-args:
   - --share=ipc
-  - --socket=x11
+  - --socket=fallback-x11
+  - --socket=wayland
   - --share=network
   - --socket=pulseaudio
   - --filesystem=host


### PR DESCRIPTION
Enable Wayland with X11 as fallback. Starting with 2026.1, IntelliJ-based IDEs will run natively on Wayland.
https://blog.jetbrains.com/platform/2026/02/wayland-by-default-in-2026-1-eap/

Closes: #115 (In IntelliJ and WebStorm with Wayland now we have these buttons)